### PR TITLE
Post endpoint test

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -38,10 +38,10 @@ router.post('/', (request, response)=>{
           rating: res.rating,
           genre: res.genre},
           "id")
-      ).then(res => response.status(201).send(`${request.body.title} by ${request.body.artistName} has been added to your favorites!`))
+      ).then(res => response.status(201).send({ message: `${request.body.title} by ${request.body.artistName} has been added to your favorites!`}))
       .catch(error => response.status(500).send(error));
     } else {
-      return response.status(400).send('There are some missing attributes in your request parameters.');
+      return response.status(400).send({message: 'There are some missing attributes in your request parameters.'});
     }
 
 });

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -98,4 +98,27 @@ describe('Test GET /api/v1/favorites path', () => {
           expect(res.statusCode).toBe(204);
           expect(res.body).toEqual({});
         });
+    });
+
+    describe('Test POST /api/v1/favorites path', () => {
+      it('respond with 400 not created', async () => {
+        await database.raw('truncate table favorites cascade');
+        const res = await request(app).post("/api/v1/favorites")
+          .send({"artistName": "Test"})
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toEqual('There are some missing attributes in your request parameters.')
       });
+
+      it('respond with 201 when created', async () => {
+        await database.raw('truncate table favorites cascade');
+        const res = await request(app).post("/api/v1/favorites")
+          .send({
+            "title": "Creep",
+            "artistName": "Radiohead"
+          })
+
+        expect(res.statusCode).toBe(201);
+        expect(res.body.message).toEqual('Creep by Radiohead has been added to your favorites!');
+        });
+    });


### PR DESCRIPTION
- Add two test cases, including sad path (400) and happy path (201).
- Add a message key to the response body