### PR TITLE
User Story 13: DELETE /api/v1/playlists/:id/favorites/:id endpoint

### DIFF
--- a/db/migrations/20191209123846_faves_playlists_joins.js
+++ b/db/migrations/20191209123846_faves_playlists_joins.js
@@ -2,8 +2,12 @@ exports.up = function(knex) {
   return Promise.all([
     knex.schema.createTable('favorites_playlists', function(table){
       table.increments('id').primary();
-      table.integer('favorite_id').references('favorites.id');
-      table.integer('playlist_id').references('playlists.id');
+      table.integer('favorite_id').references('favorites.id')
+        .onUpdate('CASCADE')
+        .onDelete('CASCADE');
+      table.integer('playlist_id').references('playlists.id')
+        .onUpdate('CASCADE')
+        .onDelete('CASCADE');
     })
   ]);
 };

--- a/models/song_playlist.js
+++ b/models/song_playlist.js
@@ -5,6 +5,10 @@ class songPlaylist{
   static add(favoriteID, playlistID) {
     return database('favorites_playlists').insert({favorite_id: favoriteID, playlist_id: playlistID}, "id")
   }
+
+  static find(favoriteID, playlistID) {
+    return database('favorites_playlists').where({favorite_id: favoriteID, playlist_id: playlistID})
+  }
 }
 
 module.exports = songPlaylist;

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -124,4 +124,30 @@ router.post('/:id/favorites/:fave_id', async (request, response) => {
   }
 })
 
+router.delete('/:id/favorites/:fave_id', async (request, response)=>{
+  const playlistID = request.params.id;
+  const favoriteID = request.params.fave_id;
+
+  const temp_playlist = await playlist.findPlaylist(playlistID)
+    .then(playlistData => {
+        return playlistData[0]
+    });
+
+  const temp_favorite = await favorite.findSong(favoriteID)
+    .then(songData => {
+        return songData[0]
+    });
+
+  songPlaylist.find(favoriteID, playlistID)
+    .then(res => {
+      if (res.length) {
+        songPlaylist.find(favoriteID, playlistID).del()
+        .then(res => response.send(204))
+      } else{
+        response.send(404, {message: "That song could not be deleted, because it does not exist."})
+      }
+    })
+    .catch(error => response.status(500).send(error));
+});
+
 module.exports = router;


### PR DESCRIPTION
- in schema, added `onDelete CASCADE` to remove relations between favorite and playlist (without removing original records)